### PR TITLE
fix(sites): Add a default site_id on start

### DIFF
--- a/mezzanine/utils/sites.py
+++ b/mezzanine/utils/sites.py
@@ -63,8 +63,8 @@ def current_site_id():
                     if cache_installed():
                         cache_set(cache_key, site_id)
     # Executed when application is restarting
-    # if not site_id:
-    #     site_id = os.environ.get("MEZZANINE_SITE_ID", settings.SITE_ID)
+    if not site_id:
+        site_id = os.environ.get("MEZZANINE_SITE_ID", settings.SITE_ID)
     if request and site_id and not getattr(settings, "TESTING", False):
         request.site_id = site_id
     return site_id


### PR DESCRIPTION
Hey,

May we revert this change and set back a default `site_id` on start ?

This would :
- Avoid configuring a local nginx server for routing request to the appropriate site
- Allows setting the SITE_ID in dev in the `settings.py` file

What would be the drawbacks if that would be merged @ezawadzki ?
Is there a way we could restore that ?
Maybe we can fix the root issue with the `with override_current_site_id(id)` pattern.

Open to discussion :)